### PR TITLE
Bump to-float32 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "object-assign": "^4.1.1",
     "parse-rect": "^1.2.0",
     "pick-by-alias": "^1.2.0",
-    "to-float32": "^1.0.1",
+    "to-float32": "^1.1.0",
     "update-diff": "^1.1.0"
   },
   "devDependencies": {

--- a/scatter.js
+++ b/scatter.js
@@ -565,12 +565,14 @@ Scatter.prototype.update = function (...args) {
 				}
 
 				// update position buffers
-				positionBuffer({
-					data: f32.float(positions),
+				var float_data = f32.float32(positions)
+				state.positionBuffer({
+					data: float_data,
 					usage: 'dynamic'
 				})
-				positionFractBuffer({
-					data: f32.fract(positions),
+				var frac_data = f32.fract32(positions, float_data)
+				state.positionFractBuffer({
+					data: frac_data,
 					usage: 'dynamic'
 				})
 


### PR DESCRIPTION
Upgrades to-float32 package and uses the new version to improve the performance when drawing.

You can see the to-float32 package changes [here](https://github.com/dy/to-float32/pull/1)

Other packages PRs: [here](https://github.com/gl-vis/regl-line2d/pull/50), [here](https://github.com/gl-vis/regl-error2d/pull/9)

@archmoj

cc: @alexcjohnson 