### PR TITLE
rename uniform variable names of regl-scatter2d module

### DIFF
--- a/circle-frag.glsl
+++ b/circle-frag.glsl
@@ -1,9 +1,9 @@
 precision highp float;
 
 varying vec4 fragColor, fragBorderColor;
+varying float fragBorderRadius, fragWidth;
 
 uniform float opacity;
-varying float fragBorderRadius, fragWidth;
 
 float smoothStep(float edge0, float edge1, float x) {
 	float t;

--- a/circle-vert.glsl
+++ b/circle-vert.glsl
@@ -5,11 +5,10 @@ attribute float size, borderSize;
 attribute vec4 colorId, borderColorId;
 attribute float isActive;
 
-uniform vec2 scale, scaleFract, translate, translateFract;
-uniform float pixelRatio;
 uniform bool constPointSize;
-uniform sampler2D palette;
-uniform vec2 paletteSize;
+uniform float pixelRatio;
+uniform vec2 paletteSize, scale, scaleFract, translate, translateFract;
+uniform sampler2D paletteTexture;
 
 const float maxSize = 100.;
 
@@ -21,7 +20,7 @@ float pointSizeScale = (constPointSize) ? 2. : pixelRatio;
 bool isDirect = (paletteSize.x < 1.);
 
 vec4 getColor(vec4 id) {
-  return isDirect ? id / 255. : texture2D(palette,
+  return isDirect ? id / 255. : texture2D(paletteTexture,
     vec2(
       (id.x + .5) / paletteSize.x,
       (id.y + .5) / paletteSize.y

--- a/marker-frag.glsl
+++ b/marker-frag.glsl
@@ -1,17 +1,18 @@
 precision highp float;
 
+uniform sampler2D markerTexture;
+uniform float opacity;
+
 varying vec4 fragColor, fragBorderColor;
 varying float fragWidth, fragBorderColorLevel, fragColorLevel;
 
-uniform sampler2D marker;
-uniform float opacity;
 
 float smoothStep(float x, float y) {
   return 1.0 / (1.0 + exp(50.0*(x - y)));
 }
 
 void main() {
-  float dist = texture2D(marker, gl_PointCoord).r, delta = fragWidth;
+  float dist = texture2D(markerTexture, gl_PointCoord).r, delta = fragWidth;
 
   // max-distance alpha
   if (dist < 0.003) discard;

--- a/marker-vert.glsl
+++ b/marker-vert.glsl
@@ -5,10 +5,10 @@ attribute float size, borderSize;
 attribute vec4 colorId, borderColorId;
 attribute float isActive;
 
-uniform vec2 scale, scaleFract, translate, translateFract, paletteSize;
-uniform float pixelRatio;
 uniform bool constPointSize;
-uniform sampler2D palette;
+uniform float pixelRatio;
+uniform vec2 scale, scaleFract, translate, translateFract, paletteSize;
+uniform sampler2D paletteTexture;
 
 const float maxSize = 100.;
 const float borderLevel = .5;
@@ -21,7 +21,7 @@ float pointSizeScale = (constPointSize) ? 2. : pixelRatio;
 bool isDirect = (paletteSize.x < 1.);
 
 vec4 getColor(vec4 id) {
-  return isDirect ? id / 255. : texture2D(palette,
+  return isDirect ? id / 255. : texture2D(paletteTexture,
     vec2(
       (id.x + .5) / paletteSize.x,
       (id.y + .5) / paletteSize.y

--- a/scatter.js
+++ b/scatter.js
@@ -82,15 +82,15 @@ function Scatter (regl, options) {
 	let shaderOptions = {
 		uniforms: {
 			constPointSize: !!options.constPointSize,
-			pixelRatio: regl.context('pixelRatio'),
-			palette: paletteTexture,
+			opacity: regl.prop('opacity'),
 			paletteSize: (ctx, prop) => [this.tooManyColors ? 0 : maxColors, paletteTexture.height],
+			pixelRatio: regl.context('pixelRatio'),
 			scale: regl.prop('scale'),
 			scaleFract: regl.prop('scaleFract'),
 			translate: regl.prop('translate'),
 			translateFract: regl.prop('translateFract'),
-			opacity: regl.prop('opacity'),
-			marker: regl.prop('markerTexture'),
+			markerTexture: regl.prop('markerTexture'),
+			paletteTexture: paletteTexture,
 		},
 
 		attributes: {


### PR DESCRIPTION
improves readability as well as helps having more deterministic `regl` functions at runtime on different browsers while addressing https://github.com/plotly/plotly.js/issues/897.

cc: @alexcjohnson
